### PR TITLE
More flexible adlfs version pin to allow newer versions.

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - xarray
     - intake-xarray
     - zarr>=2
-    - adlfs=0.5.5
+    - adlfs>=0.5.9
     - h5netcdf>=0.8
     - intake
   host:
@@ -35,7 +35,7 @@ requirements:
     - xarray
     - intake-xarray
     - zarr>=2
-    - adlfs=0.5.5
+    - adlfs>=0.5.9
     - h5netcdf>=0.8
     - intake
 test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ xarray
 intake-xarray
 conda-build
 fsspec
-adlfs==0.5.5
+adlfs>=0.5.9
 h5netcdf
 zarr
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "dask>=1.0",
         "xarray",
         "zarr>=2",
-        "adlfs==0.5.5",
+        "adlfs>=0.5.9",
         "h5netcdf>=0.8",
         "intake",
         "intake-xarray",


### PR DESCRIPTION
Avoids 0.5.7 and 0.5.8 which were broken when using credential for authentication.